### PR TITLE
add zk authInfo support

### DIFF
--- a/lib/data_client.js
+++ b/lib/data_client.js
@@ -13,7 +13,10 @@ class DataClient extends Base {
       initMethod: '_init',
     }));
     this.clientId = process.pid + ':' + _clientId++;
+    const { authInfo: { scheme, auth } } = this.options;
+    delete this.options.authInfo;
     this._zookeeperClient = zookeeper.createClient(this.options.connectionString, this.options);
+    if (scheme && auth) this._zookeeperClient.addAuthInfo(scheme, new Buffer(auth));
     this._zookeeperClientStartConnect = false;
     this._zookeeperClientConnected = false;
     this._zookeeperClientClosed = false;

--- a/lib/data_client.js
+++ b/lib/data_client.js
@@ -13,8 +13,9 @@ class DataClient extends Base {
       initMethod: '_init',
     }));
     this.clientId = process.pid + ':' + _clientId++;
-    const { authInfo: { scheme, auth } } = this.options;
+    const { authInfo = {} } = this.options;
     delete this.options.authInfo;
+    const { scheme, auth } = authInfo;
     this._zookeeperClient = zookeeper.createClient(this.options.connectionString, this.options);
     if (scheme && auth) this._zookeeperClient.addAuthInfo(scheme, new Buffer(auth));
     this._zookeeperClientStartConnect = false;


### PR DESCRIPTION
连接zk时可能需要acl认证支持。配合sofa-rpc-node,在registry的配置信息中添加authInfo,即可自动调用node-zookeeper-client的addAuthInfo方法进行认证。示例：

const { ZookeeperRegistry } = require('sofa-rpc-node').registry;

//  create zk registry client
const registry = new ZookeeperRegistry({
  address: '127.0.0.1:2181',
  authInfo: { scheme: 'digest', auth: 'user:password' },
});
